### PR TITLE
Bump version: 2.0.0 → 2.1.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,7 +2,7 @@
 commit = True
 tag = True
 tag_name = {new_version}
-current_version = 2.0.0
+current_version = 2.1.0
 
 [bumpversion:file:setup.py]
 search = version='{current_version}'
@@ -15,3 +15,4 @@ replace = __version__ = '{new_version}'
 [bumpversion:file:README.md]
 search = > Version {current_version}
 replace = > Version {new_version}
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # bind
 
 <!--- Don't edit the version line below manually. Let bump2version do it for you. -->
-> Version 2.0.0
+> Version 2.1.0
 
 > bind is a function that joins strings in a way we often need
 

--- a/bind/__init__.py
+++ b/bind/__init__.py
@@ -1,3 +1,3 @@
 from .bind import bind  # noqa
 
-__version__ = '2.0.0'  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
+__version__ = '2.1.0'  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(fname):
 
 setup(
       name='bind',
-      version='2.0.0',  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
+      version='2.1.0',  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
       description='A function for binding strings with a separator',
       author='Bitpanda GmbH',
       author_email='nosupport@bitpanda.com',


### PR DESCRIPTION
* Gives us a version with PEP561 compatibility (access to typehints).