### PR TITLE
correct handling of falsey numbers

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,7 +2,7 @@
 commit = True
 tag = True
 tag_name = {new_version}
-current_version = 2.1.0
+current_version = 3.0.0
 
 [bumpversion:file:setup.py]
 search = version='{current_version}'
@@ -15,4 +15,3 @@ replace = __version__ = '{new_version}'
 [bumpversion:file:README.md]
 search = > Version {current_version}
 replace = > Version {new_version}
-

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # bind
 
 <!--- Don't edit the version line below manually. Let bump2version do it for you. -->
-> Version 2.1.0
+> Version 3.0.0
 
 > bind is a function that joins strings in a way we often need
 

--- a/README.md
+++ b/README.md
@@ -11,30 +11,31 @@
 
 ```python
 from bind import bind
-things_to_bind = ['castable', 'to', 's t r i n g.', 45, '"hi"', 0.25]
+# False and None are dropped, but 0 and other falsey things are not
+things_to_bind = ['castable', 'to', 's t r i n g.', 0, False, None, 45, '"hi"', 0.25]
 
 # defaults for urllib.parse.quote_plus, leaving these out would change nothing
 kwargs = dict(safe='', encoding=None, errors=None) 
 
 # by default, use slash separator and urlencoding
 bind(*things_to_bind, **kwargs)
-'castable/to/s+t+r+i+n+g./45/%22hi%22/0.25'
+'castable/to/s+t+r+i+n+g./0/45/%22hi%22/0.25'
 
 # turn off url encoding
 bind(*things_to_bind, url=False, **kwargs)
-'castable/to/s t r i n g./45/"hi"/0.25'
+'castable/to/s t r i n g./0/45/"hi"/0.25'
 
 # result is the same if you pass in a list
 bind(things_to_bind, url=False, **kwargs)
-'castable/to/s t r i n g./45/"hi"/0.25'
+'castable/to/s t r i n g./0/45/"hi"/0.25'
 
 # change separator --- note that it strips the other . in things_to_bind[2]
 bind(*things_to_bind, sep='.')
-'castable.to.s+t+r+i+n+g.45.%22hi%22.0.25'
+'castable.to.s+t+r+i+n+g.0.45.%22hi%22.0.25'
 
 # pointless but possible, and will strip W, H and Y from items in iterable!
 bind(*things_to_bind, sep='WHY', url=True, **kwargs)
-'castableWHYtoWHYs+t+r+i+n+g.WHY45WHY%22hi%22WHY0.25'
+'castableWHYtoWHYs+t+r+i+n+g.WHY0WHY45WHY%22hi%22WHY0.25'
 ```
 
 Aside from `url=bool` and `sep=str`, all keyword arguments are passed to [`urllib.parse.quote_plus`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote_plus)

--- a/bind/__init__.py
+++ b/bind/__init__.py
@@ -1,3 +1,3 @@
 from .bind import bind  # noqa
 
-__version__ = '2.1.0'  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
+__version__ = '3.0.0'  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT

--- a/bind/bind.py
+++ b/bind/bind.py
@@ -13,9 +13,9 @@ def bind(*args: Union[str, list, set, tuple],
          encoding: Optional[str] = None,
          errors: Optional[str] = None) -> str:
     if isinstance(args[0], (list, set, tuple)):
-        parts = args[0]
+        parts = [i for i in args[0] if i is not False and i is not None]
     else:
-        parts = [i for i in args if i]
+        parts = [i for i in args if i is not False and i is not None]
 
     if url:
         processed_parts = (quote_plus(str(arg).strip(sep), safe=safe, encoding=encoding, errors=errors)  # type: ignore

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(fname):
 
 setup(
       name='bind',
-      version='2.1.0',  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
+      version='3.0.0',  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
       description='A function for binding strings with a separator',
       author='Bitpanda GmbH',
       author_email='nosupport@bitpanda.com',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,31 +2,31 @@ import unittest
 
 from bind import bind
 
-BIND_DATA = ['castable', 's t r i n g.', 45, '"hi"', 0.25, '/slash.', 'http://']
+BIND_DATA = ['castable', 0, False, None, 's t r i n g.', 45, '"hi"', 0.25, '/slash.', 'http://']
 
 
 class TestBind(unittest.TestCase):
 
     def test_default(self):
         bound = bind(BIND_DATA)
-        self.assertEqual(bound, 'castable/s+t+r+i+n+g./45/%22hi%22/0.25/slash./http:')
+        self.assertEqual(bound, 'castable/0/s+t+r+i+n+g./45/%22hi%22/0.25/slash./http:')
 
     def test_unpacked(self):
         bound = bind(*BIND_DATA)
-        self.assertEqual(bound, 'castable/s+t+r+i+n+g./45/%22hi%22/0.25/slash./http:')
+        self.assertEqual(bound, 'castable/0/s+t+r+i+n+g./45/%22hi%22/0.25/slash./http:')
 
     def test_url_false(self):
         bound = bind(*BIND_DATA, url=False)
-        self.assertEqual(bound, 'castable/s t r i n g./45/"hi"/0.25/slash./http:')
+        self.assertEqual(bound, 'castable/0/s t r i n g./45/"hi"/0.25/slash./http:')
 
     def test_diff_sep(self):
         bound = bind(*BIND_DATA, sep='.')
-        self.assertEqual(bound, 'castable.s+t+r+i+n+g.45.%22hi%22.0.25./slash.http://')
+        self.assertEqual(bound, 'castable.0.s+t+r+i+n+g.45.%22hi%22.0.25./slash.http://')
 
     def test_blank_sep(self):
         bound = bind(*BIND_DATA, sep='')
-        self.assertEqual(bound, 'castables+t+r+i+n+g.45%22hi%220.25/slash.http://')
+        self.assertEqual(bound, 'castable0s+t+r+i+n+g.45%22hi%220.25/slash.http://')
 
     def test_multi_sep(self):
         bound = bind(*BIND_DATA, sep='WHY')
-        self.assertEqual(bound, 'castableWHYs+t+r+i+n+g.WHY45WHY%22hi%22WHY0.25WHY/slash.WHYhttp://')
+        self.assertEqual(bound, 'castableWHY0WHYs+t+r+i+n+g.WHY45WHY%22hi%22WHY0.25WHY/slash.WHYhttp://')


### PR DESCRIPTION
@michdr 

Current behaviour has two problems when handling falsey things: inconsistency when unpacking and not unpacking, and dropping of falsey numbers:

```python
>>> from bind import bind
>>> items = ["a", "b", 0, False, None, "d"]
>>> bind(items)
'a/b/0/False/None/d'
>>> bind(*items)
'a/b/d'
```

This PR:

```python
>>> bind(items)
'a/b/0/d'
>>> bind(*items)
'a/b/0/d'
```

Please bump to 3.0.0 and put on pypi after accepting? Dankedank